### PR TITLE
Open up nokogiri dependency

### DIFF
--- a/nokogiri-cache.gemspec
+++ b/nokogiri-cache.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'benchmark-ips'
 
   spec.add_dependency 'rails', '>= 3.2.22.5', '< 5'
-  spec.add_dependency 'nokogiri', '~> 1.6.7'
+  spec.add_dependency 'nokogiri', '>= 1.6.7'
 end


### PR DESCRIPTION
`~> 1.6.7` restriction was preventing nokogiri gem update. Updating nokogiri gem due to security vulnerabilities.